### PR TITLE
refactor: modify codebase for the geovex model

### DIFF
--- a/examples/embedders/geovex_embedder.ipynb
+++ b/examples/embedders/geovex_embedder.ipynb
@@ -6,22 +6,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from srai.embedders import GeoVexEmbedder, CountEmbedder\n",
     "from srai.joiners import IntersectionJoiner\n",
     "from srai.loaders import OSMPbfLoader\n",
     "from srai.neighbourhoods import H3Neighbourhood\n",
-    "from srai.regionalizers import H3Regionalizer\n",
-    "from srai.utils import geocode_to_region_gdf\n",
+    "from srai.regionalizers import H3Regionalizer, geocode_to_region_gdf\n",
     "from srai.plotting import plot_regions, plot_numeric_data\n",
     "from pytorch_lightning import seed_everything"
    ]
@@ -58,11 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "area_gdf = geocode_to_region_gdf(\n",
-    "    [\n",
-    "        \"Greater London, UK\",\n",
-    "    ]\n",
-    ")\n",
+    "area_gdf = geocode_to_region_gdf(\"Greater London, UK\")\n",
     "plot_regions(area_gdf, tiles_style=\"CartoDB positron\")"
    ]
   },
@@ -92,34 +77,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import h3\n",
+    "from srai.h3 import ring_buffer_h3_regions_gdf\n",
     "\n",
     "resolution = 9\n",
     "k_ring_buffer_radius = 4\n",
+    "\n",
     "regionalizer = H3Regionalizer(resolution=resolution)\n",
+    "base_h3_regions = regionalizer.transform(area_gdf)\n",
     "\n",
+    "buffered_h3_regions = ring_buffer_h3_regions_gdf(base_h3_regions, distance=k_ring_buffer_radius)\n",
+    "buffered_h3_geometry = buffered_h3_regions.unary_union\n",
     "\n",
-    "def new_geometry(row, resolution, k_ring_buffer_radius, regionalizer):\n",
-    "    shp = regionalizer._polygon_shapely_to_h3(\n",
-    "        row.geometry,\n",
-    "    )\n",
-    "    cells = h3.polygon_to_cells(shp, resolution)\n",
-    "    # extend the cells by their neighbours\n",
-    "    cells = {h for cell in cells for h in h3.grid_disk(cell, k_ring_buffer_radius)}\n",
-    "\n",
-    "    p = h3.cells_to_polygons(\n",
-    "        cells,\n",
-    "    )\n",
-    "\n",
-    "    assert len(p) == 1\n",
-    "\n",
-    "    return regionalizer._polygon_h3_to_shapely(p[0])\n",
-    "\n",
-    "\n",
-    "area_gdf[\"geometry\"] = area_gdf.apply(\n",
-    "    lambda row: new_geometry(row, resolution, k_ring_buffer_radius, regionalizer),\n",
-    "    axis=1,\n",
-    ")"
+    "print(\"Base regions:\", len(base_h3_regions))\n",
+    "print(\"Buffered regions:\", len(buffered_h3_regions))"
    ]
   },
   {
@@ -149,7 +119,7 @@
     "tags = HEX2VEC_FILTER\n",
     "loader = OSMPbfLoader()\n",
     "\n",
-    "features_gdf = loader.load(area_gdf, tags)"
+    "features_gdf = loader.load(buffered_h3_geometry, tags)"
    ]
   },
   {
@@ -165,7 +135,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After downloading the data, we need to prepare it for embedding. Namely - we need to regionalize the selected area, and join the features with regions.\n"
+    "After downloading the data, we need to prepare it for embedding. In the previous step we have regionalized the selected area and buffered it, now we have to join the features with prepared regions.\n"
    ]
   },
   {
@@ -174,10 +144,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "regionalizer = H3Regionalizer(resolution=9)\n",
-    "regions_gdf = regionalizer.transform(area_gdf)\n",
-    "\n",
-    "plot_regions(regions_gdf, tiles_style=\"CartoDB positron\")"
+    "plot_regions(buffered_h3_regions, tiles_style=\"CartoDB positron\")"
    ]
   },
   {
@@ -187,7 +154,7 @@
    "outputs": [],
    "source": [
     "joiner = IntersectionJoiner()\n",
-    "joint_gdf = joiner.transform(regions_gdf, features_gdf)\n",
+    "joint_gdf = joiner.transform(buffered_h3_regions, features_gdf)\n",
     "joint_gdf"
    ]
   },
@@ -215,13 +182,13 @@
    "source": [
     "import warnings\n",
     "\n",
-    "neighbourhood = H3Neighbourhood(regions_gdf)\n",
+    "neighbourhood = H3Neighbourhood(buffered_h3_regions)\n",
     "\n",
     "embedder = GeoVexEmbedder(\n",
     "    target_features=[f\"{super_}_{sub}\" for super_, subs in HEX2VEC_FILTER.items() for sub in subs],\n",
     "    neighbourhood=neighbourhood,\n",
     "    batch_size=8,\n",
-    "    neighbourhood_radius=4,\n",
+    "    neighbourhood_radius=k_ring_buffer_radius,\n",
     "    convolutional_layers=2,\n",
     "    embedding_size=50,\n",
     ")\n",
@@ -230,12 +197,13 @@
     "    warnings.simplefilter(\"ignore\")\n",
     "\n",
     "    embeddings = embedder.fit_transform(\n",
-    "        regions_gdf=regions_gdf,\n",
+    "        regions_gdf=buffered_h3_regions,\n",
     "        features_gdf=features_gdf,\n",
     "        joint_gdf=joint_gdf,\n",
     "        neighbourhood=neighbourhood,\n",
     "        trainer_kwargs={\n",
-    "            \"max_epochs\": 20,\n",
+    "            # \"max_epochs\": 20, # uncomment for a longer training\n",
+    "            \"max_epochs\": 2,\n",
     "            \"accelerator\": \"cpu\",\n",
     "        },\n",
     "        learning_rate=0.001,\n",
@@ -261,7 +229,7 @@
     "from srai.embedders import Hex2VecEmbedder\n",
     "import warnings\n",
     "\n",
-    "neighbourhood = H3Neighbourhood(regions_gdf)\n",
+    "neighbourhood = H3Neighbourhood(buffered_h3_regions)\n",
     "\n",
     "hex2vec_embedder = Hex2VecEmbedder(\n",
     "    encoder_sizes=[300, 150, 50],\n",
@@ -271,7 +239,7 @@
     "    warnings.simplefilter(\"ignore\")\n",
     "\n",
     "    hex2vec_embeddings = hex2vec_embedder.fit_transform(\n",
-    "        regions_gdf=regions_gdf,\n",
+    "        regions_gdf=buffered_h3_regions,\n",
     "        features_gdf=features_gdf,\n",
     "        joint_gdf=joint_gdf,\n",
     "        neighbourhood=neighbourhood,\n",
@@ -279,8 +247,9 @@
     "        batch_size=64,\n",
     "        learning_rate=0.001,\n",
     "        trainer_kwargs={\n",
-    "            \"max_epochs\": 50,\n",
-    "            \"accelerator\": \"mps\",\n",
+    "            # \"max_epochs\": 50, # uncomment for a longer training\n",
+    "            \"max_epochs\": 5,\n",
+    "            \"accelerator\": \"cpu\",\n",
     "        },\n",
     "    )\n",
     "\n",
@@ -325,7 +294,7 @@
     "\n",
     "pca_embeddings = pca.fit_transform(embeddings)\n",
     "# make the embeddings into a dataframe\n",
-    "pca_embeddings = pd.DataFrame(pca_embeddings, index=hex2vec_embeddings.index)\n",
+    "pca_embeddings = pd.DataFrame(pca_embeddings, index=embeddings.index)\n",
     "\n",
     "# convert to RGB\n",
     "pca_embeddings = (\n",
@@ -338,8 +307,10 @@
     ")\n",
     "\n",
     "\n",
-    "color_dict = dict(enumerate(regions_gdf.index.map(pca_embeddings[\"rgb\"].to_dict()).to_list()))\n",
-    "regions_gdf.reset_index().reset_index().explore(\n",
+    "color_dict = dict(\n",
+    "    enumerate(buffered_h3_regions.index.map(pca_embeddings[\"rgb\"].to_dict()).to_list())\n",
+    ")\n",
+    "buffered_h3_regions.reset_index().reset_index().explore(\n",
     "    column=\"index\",\n",
     "    tooltip=\"region_id\",\n",
     "    tiles=\"CartoDB positron\",\n",
@@ -377,7 +348,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_numeric_data(regions_gdf, embeddings, \"cluster\", tiles_style=\"CartoDB positron\")"
+    "plot_numeric_data(buffered_h3_regions, \"cluster\", embeddings, tiles_style=\"CartoDB positron\")"
    ]
   },
   {
@@ -424,8 +395,10 @@
     ")\n",
     "\n",
     "\n",
-    "color_dict = dict(enumerate(regions_gdf.index.map(pca_embeddings[\"rgb\"].to_dict()).to_list()))\n",
-    "regions_gdf.reset_index().reset_index().explore(\n",
+    "color_dict = dict(\n",
+    "    enumerate(buffered_h3_regions.index.map(pca_embeddings[\"rgb\"].to_dict()).to_list())\n",
+    ")\n",
+    "buffered_h3_regions.reset_index().reset_index().explore(\n",
     "    column=\"index\",\n",
     "    tooltip=\"region_id\",\n",
     "    tiles=\"CartoDB positron\",\n",
@@ -463,7 +436,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_numeric_data(regions_gdf, hex2vec_embeddings, \"cluster\", tiles_style=\"CartoDB positron\")"
+    "plot_numeric_data(\n",
+    "    buffered_h3_regions, \"cluster\", hex2vec_embeddings, tiles_style=\"CartoDB positron\"\n",
+    ")"
    ]
   }
  ],
@@ -483,7 +458,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/srai/loaders/osm_loaders/_base.py
+++ b/srai/loaders/osm_loaders/_base.py
@@ -1,20 +1,52 @@
 """Base class for OSM loaders."""
 
 import abc
-from typing import Optional, Union, cast
+from typing import Iterable, Optional, Union, cast
 
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+from shapely.geometry.base import BaseGeometry
 from tqdm import tqdm
 
 from srai._typing import is_expected_type
+from srai.constants import WGS84_CRS
 from srai.loaders import Loader
 from srai.loaders.osm_loaders.filters import (
     GroupedOsmTagsFilter,
     OsmTagsFilter,
     merge_grouped_osm_tags_filter,
 )
+
+
+def prepare_area_gdf_for_loader(
+    area: Union[BaseGeometry, Iterable[BaseGeometry], gpd.GeoSeries, gpd.GeoDataFrame]
+) -> gpd.GeoDataFrame:
+    """
+    Prepare an area for the loader.
+
+    Loader expects a GeoDataFrame input, but users shouldn't be limited by this requirement.
+    All Shapely geometries will by transformed into GeoDataFrame with proper CRS.
+
+    Args:
+        area (Union[BaseGeometry, Iterable[BaseGeometry], gpd.GeoSeries, gpd.GeoDataFrame]):
+            Area to be parsed into GeoDataFrame.
+
+    Returns:
+        gpd.GeoDataFrame: Sanitized GeoDataFrame.
+    """
+    if isinstance(area, gpd.GeoDataFrame):
+        # Return a GeoDataFrame with changed CRS
+        return area.to_crs(WGS84_CRS)
+    elif isinstance(area, gpd.GeoSeries):
+        # Create a GeoDataFrame with GeoSeries
+        return gpd.GeoDataFrame(geometry=area, crs=WGS84_CRS)
+    elif isinstance(area, Iterable):
+        # Create a GeoSeries with a list of geometries
+        return prepare_area_gdf_for_loader(gpd.GeoSeries(area, crs=WGS84_CRS))
+    else:
+        # Wrap a single geometry with a list
+        return prepare_area_gdf_for_loader([area])
 
 
 class OSMLoader(Loader, abc.ABC):
@@ -25,20 +57,26 @@ class OSMLoader(Loader, abc.ABC):
     @abc.abstractmethod
     def load(
         self,
-        area: gpd.GeoDataFrame,
+        area: Union[BaseGeometry, Iterable[BaseGeometry], gpd.GeoSeries, gpd.GeoDataFrame],
         tags: Union[OsmTagsFilter, GroupedOsmTagsFilter],
     ) -> gpd.GeoDataFrame:  # pragma: no cover
         """
         Load data for a given area.
 
         Args:
-            area (gpd.GeoDataFrame): GeoDataFrame with the area of interest.
+            area (Union[BaseGeometry, Iterable[BaseGeometry], gpd.GeoSeries, gpd.GeoDataFrame]):
+                Shapely geometry with the area of interest.
             tags (Union[OsmTagsFilter, GroupedOsmTagsFilter]): OSM tags filter.
 
         Returns:
             gpd.GeoDataFrame: GeoDataFrame with the downloaded data.
         """
         raise NotImplementedError
+
+    def _prepare_area_gdf(
+        self, area: Union[BaseGeometry, Iterable[BaseGeometry], gpd.GeoSeries, gpd.GeoDataFrame]
+    ) -> gpd.GeoDataFrame:
+        return prepare_area_gdf_for_loader(area)
 
     def _merge_osm_tags_filter(
         self, tags: Union[OsmTagsFilter, GroupedOsmTagsFilter]

--- a/srai/loaders/osm_loaders/osm_pbf_loader.py
+++ b/srai/loaders/osm_loaders/osm_pbf_loader.py
@@ -4,10 +4,11 @@ OSM PBF Loader.
 This module contains loader capable of loading OpenStreetMap features from `*.osm.pbf` files.
 """
 from pathlib import Path
-from typing import Hashable, List, Mapping, Optional, Sequence, Union
+from typing import Hashable, Iterable, List, Mapping, Optional, Sequence, Union
 
 import geopandas as gpd
 import pandas as pd
+from shapely.geometry.base import BaseGeometry
 
 from srai._optional import import_optional_dependencies
 from srai.constants import FEATURES_INDEX, GEOMETRY_COLUMN, WGS84_CRS
@@ -54,7 +55,7 @@ class OSMPbfLoader(OSMLoader):
 
     def load(
         self,
-        area: gpd.GeoDataFrame,
+        area: Union[BaseGeometry, Iterable[BaseGeometry], gpd.GeoSeries, gpd.GeoDataFrame],
         tags: Union[OsmTagsFilter, GroupedOsmTagsFilter],
     ) -> gpd.GeoDataFrame:
         """
@@ -74,7 +75,8 @@ class OSMPbfLoader(OSMLoader):
             the constructor of the `OSMPbfLoader`.
 
         Args:
-            area (gpd.GeoDataFrame): Area for which to download objects.
+            area (Union[BaseGeometry, Iterable[BaseGeometry], gpd.GeoSeries, gpd.GeoDataFrame]):
+                Area for which to download objects.
             tags (Union[OsmTagsFilter, GroupedOsmTagsFilter]): A dictionary
                 specifying which tags to download.
                 The keys should be OSM tags (e.g. `building`, `amenity`).
@@ -91,7 +93,7 @@ class OSMPbfLoader(OSMLoader):
         from srai.loaders.osm_loaders.pbf_file_downloader import PbfFileDownloader
         from srai.loaders.osm_loaders.pbf_file_handler import PbfFileHandler
 
-        area_wgs84 = area.to_crs(crs=WGS84_CRS)
+        area_wgs84 = self._prepare_area_gdf(area)
 
         downloaded_pbf_files: Mapping[Hashable, Sequence[Union[str, Path]]]
         if self.pbf_file is not None:

--- a/srai/loaders/osm_loaders/osm_tile_loader.py
+++ b/srai/loaders/osm_loaders/osm_tile_loader.py
@@ -5,14 +5,16 @@ This module implements downloading tiles from given OSM tile server.
 """
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Iterable, Optional, Union
 from urllib.parse import urljoin
 
 import geopandas as gpd
 import pandas as pd
 import requests
+from shapely.geometry.base import BaseGeometry
 
 from srai._optional import import_optional_dependencies
+from srai.loaders.osm_loaders._base import prepare_area_gdf_for_loader
 from srai.regionalizers.slippy_map_regionalizer import SlippyMapRegionalizer
 
 from .osm_tile_data_collector import (
@@ -92,18 +94,20 @@ class OSMTileLoader:
 
     def load(
         self,
-        area: gpd.GeoDataFrame,
+        area: Union[BaseGeometry, Iterable[BaseGeometry], gpd.GeoSeries, gpd.GeoDataFrame],
     ) -> gpd.GeoDataFrame:
         """
         Return all tiles of region.
 
         Args:
-            area (gpd.GeoDataFrame): Area for which to download objects.
+            area (Union[BaseGeometry, Iterable[BaseGeometry], gpd.GeoSeries, gpd.GeoDataFrame]):
+                Area for which to download objects.
 
         Returns:
             gpd.GeoDataFrame: Pandas of tiles for each region in area transformed by DataCollector
         """
-        regions = self.regionalizer.transform(gdf=area)
+        area_wgs84 = prepare_area_gdf_for_loader(area)
+        regions = self.regionalizer.transform(gdf=area_wgs84)
         regions["tile"] = regions.apply(lambda row: self._get_tile_for_area(row), axis=1)
         return regions
 


### PR DESCRIPTION
I've added some changes to the main code to simplify the usage of the new GeoVex implementation.

Here is the full list of changes: 
 - Modified `ring_buffer_geometry` function and added two new ones: `ring_buffer_h3_indexes` and `ring_buffer_h3_regions_gdf`
 - Allowed all OSM Loaders to load data for any geometry, not only GeoDataFrames - it will simplify the usage, without the need for artificial Geodataframes wrangling
- Refactored geovex_embedder example (changed flow, used new functions, fixed minor issues with embeddings and visualizations)